### PR TITLE
Replace Canvas indicator with Row-based boxes

### DIFF
--- a/PagerIndicator/src/main/java/com/tek/pagerindicator/PagerIndicator.kt
+++ b/PagerIndicator/src/main/java/com/tek/pagerindicator/PagerIndicator.kt
@@ -1,17 +1,21 @@
 package com.tek.pagerindicator
 
 import androidx.compose.animation.animateColorAsState
-import androidx.compose.animation.core.animateFloatAsState
-import androidx.compose.animation.core.animateOffsetAsState
-import androidx.compose.foundation.Canvas
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.draw.clip
+import androidx.compose.foundation.background
+import androidx.compose.foundation.shape.CircleShape
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.PagerState
 
@@ -20,7 +24,6 @@ import com.google.accompanist.pager.PagerState
 internal fun PagerIndicatorKernel(
     pageCount: Int,
     currentIndex: Int,
-    intSize: IntSize,
     dotStyle: DotStyle = DotStyle.defaultDotStyle,
     dotAnimation: DotAnimation = DotAnimation.defaultDotAnimation,
     orientation: Orientation = Orientation.Vertical
@@ -61,56 +64,66 @@ internal fun PagerIndicatorKernel(
 
     }
 
-    val indicatorController =
-        rememberIndicatorController(
-            count = pageCount,
-            size = intSize,
-            dotStyle = dotStyle,
-            orientation = orientation,
-            startIndex = page,
-            startRange = range.startIndex..range.endIndex
-
-        )
-
     LaunchedEffect(currentIndex) {
-        indicatorController.pageChanged(currentIndex)
         page = currentIndex
         updateRange(currentIndex)
     }
 
+    fun colorForIndex(index: Int) =
+        if (index == page) dotStyle.currentDotColor else dotStyle.regularDotColor
 
-    indicatorController.clearAll()
-    for (i in 0 until pageCount) {
-        indicatorController.sizes.add(
-            animateFloatAsState(
-                targetValue = indicatorController.sizeTargets[i],
-                dotAnimation.sizeAnim
-            )
-        )
-        indicatorController.offSets.add(
-            animateOffsetAsState(
-                targetValue = indicatorController.offsetTargets[i],
-                dotAnimation.offsetAnim
-            )
-        )
-        indicatorController.colors.add(
-            animateColorAsState(
-                targetValue = indicatorController.colorTargets[i],
-                dotAnimation.colorAnim
-            )
-        )
+    fun sizeForIndex(index: Int): Float {
+        return when (index) {
+            page -> dotStyle.currentDotRadius
+            range.startIndex -> if (range.startIndex != 0) dotStyle.notLastDotRadius else dotStyle.regularDotRadius
+            range.endIndex -> if (range.endIndex != pageCount - 1) dotStyle.notLastDotRadius else dotStyle.regularDotRadius
+            else -> dotStyle.regularDotRadius
+        }
     }
 
+    val space = with(LocalDensity.current) { dotStyle.dotMargin.toDp() }
 
-    Canvas(modifier = Modifier.fillMaxSize(), onDraw = {
-        for (i in 0 until pageCount) {
-            drawCircle(
-                indicatorController.colors[i].value,
-                radius = indicatorController.sizes[i].value,
-                center = indicatorController.offSets[i].value
-            )
+    if (orientation == Orientation.Vertical) {
+        Row(horizontalArrangement = Arrangement.spacedBy(space)) {
+            for (i in range.startIndex..range.endIndex) {
+                val targetRadius = sizeForIndex(i)
+                val sizeAnim = animateDpAsState(
+                    targetValue = with(LocalDensity.current) { (targetRadius * 2).toDp() },
+                    animationSpec = dotAnimation.sizeAnim
+                )
+                val colorAnim = animateColorAsState(
+                    targetValue = colorForIndex(i),
+                    animationSpec = dotAnimation.colorAnim
+                )
+                Box(
+                    modifier = Modifier
+                        .size(sizeAnim.value)
+                        .clip(CircleShape)
+                        .background(colorAnim.value)
+                )
+            }
         }
-    })
+    } else {
+        Column(verticalArrangement = Arrangement.spacedBy(space)) {
+            for (i in range.startIndex..range.endIndex) {
+                val targetRadius = sizeForIndex(i)
+                val sizeAnim = animateDpAsState(
+                    targetValue = with(LocalDensity.current) { (targetRadius * 2).toDp() },
+                    animationSpec = dotAnimation.sizeAnim
+                )
+                val colorAnim = animateColorAsState(
+                    targetValue = colorForIndex(i),
+                    animationSpec = dotAnimation.colorAnim
+                )
+                Box(
+                    modifier = Modifier
+                        .size(sizeAnim.value)
+                        .clip(CircleShape)
+                        .background(colorAnim.value)
+                )
+            }
+        }
+    }
 }
 
 
@@ -142,23 +155,13 @@ fun PagerIndicator(
     dotAnimation: DotAnimation = DotAnimation.defaultDotAnimation,
     orientation: Orientation = Orientation.Vertical
 ) {
-    BoxWithConstraints(modifier = modifier) {
-        val density = LocalDensity.current
-        val h = this.maxHeight
-        val w = this.maxWidth
+    Box(modifier = modifier) {
         PagerIndicatorKernel(
             pageCount = pageCount,
             currentIndex = currentIndex,
-            intSize = with(density) {
-                IntSize(
-                    w.toPx().toInt(),
-                    h.toPx().toInt()
-                )
-            },
             orientation = orientation,
             dotStyle = dotStyle,
             dotAnimation = dotAnimation
         )
-
     }
 }

--- a/PagerIndicator/src/main/java/com/tek/pagerindicator/PagerIndicator.kt
+++ b/PagerIndicator/src/main/java/com/tek/pagerindicator/PagerIndicator.kt
@@ -3,10 +3,10 @@ package com.tek.pagerindicator
 import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.foundation.gestures.Orientation
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
@@ -84,7 +84,7 @@ internal fun PagerIndicatorKernel(
     val space = with(LocalDensity.current) { dotStyle.dotMargin.toDp() }
 
     if (orientation == Orientation.Vertical) {
-        Row(horizontalArrangement = Arrangement.spacedBy(space)) {
+        Row {
             for (i in range.startIndex..range.endIndex) {
                 val targetRadius = sizeForIndex(i)
                 val sizeAnim = animateDpAsState(
@@ -97,6 +97,7 @@ internal fun PagerIndicatorKernel(
                 )
                 Box(
                     modifier = Modifier
+                        .padding(end = if (i != range.endIndex) space else 0.dp)
                         .size(sizeAnim.value)
                         .clip(CircleShape)
                         .background(colorAnim.value)
@@ -104,7 +105,7 @@ internal fun PagerIndicatorKernel(
             }
         }
     } else {
-        Column(verticalArrangement = Arrangement.spacedBy(space)) {
+        Column {
             for (i in range.startIndex..range.endIndex) {
                 val targetRadius = sizeForIndex(i)
                 val sizeAnim = animateDpAsState(
@@ -117,6 +118,7 @@ internal fun PagerIndicatorKernel(
                 )
                 Box(
                     modifier = Modifier
+                        .padding(bottom = if (i != range.endIndex) space else 0.dp)
                         .size(sizeAnim.value)
                         .clip(CircleShape)
                         .background(colorAnim.value)


### PR DESCRIPTION
## Summary
- reimplement PagerIndicator using Row/Column with Box dots
- remove Canvas and offset animations

## Testing
- `./gradlew :PagerIndicator:assemble` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6855a36ee85c832480b720df5d55d0aa