### PR TITLE
Add transition effect to hide dots while scrolling

### DIFF
--- a/PagerIndicator/src/main/java/com/tek/pagerindicator/DotStyle.kt
+++ b/PagerIndicator/src/main/java/com/tek/pagerindicator/DotStyle.kt
@@ -9,7 +9,11 @@ data class DotStyle(
     val dotMargin: Float,
     val visibleDotCount: Int,
     val currentDotColor: Color,
-    val regularDotColor: Color
+    val regularDotColor: Color,
+    /**
+     * Number of dots to hide while a page transition is running.
+     */
+    val hideDuringScrollCount: Int = 0
 ) {
     init {
         require(visibleDotCount > 2) { "Visible dot count must be greater than 2" }
@@ -17,6 +21,10 @@ data class DotStyle(
         require(notLastDotRadius > 0f) { "Not last dot radius must be greater than 0F" }
         require(regularDotRadius > 0f) { "Regular dot radius must be greater than 0F" }
         require(dotMargin > 0f) { "Dot margin must be greater than 0F" }
+        require(hideDuringScrollCount >= 0) { "Hide dot count must be >= 0" }
+        require(hideDuringScrollCount <= visibleDotCount) {
+            "Hide dot count must be <= visible dot count"
+        }
     }
 
     companion object {
@@ -34,7 +42,8 @@ data class DotStyle(
             defaultDotMargin,
             defaultVisibleDotCount,
             defaultCurrentDotColor,
-            defaultRegularDotColor
+            defaultRegularDotColor,
+            hideDuringScrollCount = 0
         )
     }
 }

--- a/PagerIndicator/src/main/java/com/tek/pagerindicator/IndicatorController.kt
+++ b/PagerIndicator/src/main/java/com/tek/pagerindicator/IndicatorController.kt
@@ -21,6 +21,8 @@ internal class IndicatorController(
     startRange: IntRange = startIndex..dotStyle.visibleDotCount.minus(1)
 
 ) : IndicatorRangeProcessor, IndicatorMovementProcessor {
+    private val hideDuringScrollCount = dotStyle.hideDuringScrollCount
+    private var isTransitioning = false
     private var selectedIndex = mutableStateOf(startIndex)
 
     internal val colorTargets = SnapshotStateList<Color>()
@@ -199,6 +201,23 @@ internal class IndicatorController(
         sizeTargets[selectedIndex.value] = dotStyle.currentDotRadius
         colorTargets[selectedIndex.value] = dotStyle.currentDotColor
 
+    }
+
+    fun transitionStart() {
+        if (isTransitioning) return
+        isTransitioning = true
+        val hide = hideDuringScrollCount.coerceAtMost(count)
+        for (i in 0 until hide) {
+            sizeTargets[i] = 0f
+        }
+    }
+
+    fun transitionEnd() {
+        if (!isTransitioning) return
+        isTransitioning = false
+        for (i in 0 until count) {
+            sizeTargets[i] = sizeFinder(i)
+        }
     }
 
 }

--- a/PagerIndicator/src/main/java/com/tek/pagerindicator/PagerIndicator.kt
+++ b/PagerIndicator/src/main/java/com/tek/pagerindicator/PagerIndicator.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
 import com.google.accompanist.pager.ExperimentalPagerApi
 import com.google.accompanist.pager.PagerState
+import kotlinx.coroutines.delay
 
 @OptIn(ExperimentalPagerApi::class)
 @Composable
@@ -73,9 +74,12 @@ internal fun PagerIndicatorKernel(
         )
 
     LaunchedEffect(currentIndex) {
+        indicatorController.transitionStart()
         indicatorController.pageChanged(currentIndex)
         page = currentIndex
         updateRange(currentIndex)
+        delay(300)
+        indicatorController.transitionEnd()
     }
 
 


### PR DESCRIPTION
## Summary
- add `hideDuringScrollCount` parameter to `DotStyle`
- update `IndicatorController` to hide dots during transitions
- start and end transitions in `PagerIndicator` with delay

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6855aa3ac194832497cac286a036d4d0