### PR TITLE
Add fade out/in animation to PagerIndicator

### DIFF
--- a/PagerIndicator/src/main/java/com/tek/pagerindicator/DotAnimation.kt
+++ b/PagerIndicator/src/main/java/com/tek/pagerindicator/DotAnimation.kt
@@ -11,7 +11,8 @@ import androidx.compose.ui.graphics.Color
 data class DotAnimation(
     val sizeAnim: AnimationSpec<Float>,
     val offsetAnim: AnimationSpec<Offset>,
-    val colorAnim: AnimationSpec<Color>
+    val colorAnim: AnimationSpec<Color>,
+    val alphaAnim: AnimationSpec<Float>
 ) {
     companion object {
         val defaultDotAnimation = DotAnimation(
@@ -23,7 +24,11 @@ data class DotAnimation(
                 durationMillis = 1000,
                 easing = FastOutSlowInEasing
             ),
-            spring()
+            spring(),
+            tween<Float>(
+                durationMillis = 300,
+                easing = LinearEasing
+            )
         )
     }
 }

--- a/PagerIndicator/src/main/java/com/tek/pagerindicator/DotAnimation.kt
+++ b/PagerIndicator/src/main/java/com/tek/pagerindicator/DotAnimation.kt
@@ -26,7 +26,7 @@ data class DotAnimation(
             ),
             spring(),
             tween<Float>(
-                durationMillis = 300,
+                durationMillis = 1000,
                 easing = LinearEasing
             )
         )

--- a/PagerIndicator/src/main/java/com/tek/pagerindicator/IndicatorController.kt
+++ b/PagerIndicator/src/main/java/com/tek/pagerindicator/IndicatorController.kt
@@ -34,6 +34,9 @@ internal class IndicatorController(
     internal val offsetTargets = SnapshotStateList<Offset>()
     internal val offSets = mutableListOf<State<Offset>>()
 
+    internal val alphaTargets = SnapshotStateList<Float>()
+    internal val alphas = mutableListOf<State<Float>>()
+
     private var visibleRange = startRange
 
     init {
@@ -42,6 +45,7 @@ internal class IndicatorController(
             colorTargets.add(colorFinder(i))
             sizeTargets.add(sizeFinder(i))
             offsetTargets.add(Offset.Zero)
+            alphaTargets.add(alphaFinder(i))
         }
         computeOffsets()
     }
@@ -50,6 +54,7 @@ internal class IndicatorController(
         sizes.clear()
         offSets.clear()
         colors.clear()
+        alphas.clear()
     }
 
     fun pageChanged(index: Int) {
@@ -71,6 +76,7 @@ internal class IndicatorController(
         for (i in 0 until count) {
             sizeTargets[i] = sizeFinder(i)
             colorTargets[i] = colorFinder(i)
+            alphaTargets[i] = alphaFinder(i)
         }
         computeOffsets()
     }
@@ -83,6 +89,7 @@ internal class IndicatorController(
         for (i in 0 until count) {
             sizeTargets[i] = sizeFinder(i)
             colorTargets[i] = colorFinder(i)
+            alphaTargets[i] = alphaFinder(i)
         }
         computeOffsets()
 
@@ -103,6 +110,10 @@ internal class IndicatorController(
             in visibleRange -> dotStyle.regularDotRadius
             else -> 0f
         }
+    }
+
+    private fun alphaFinder(index: Int): Float {
+        return if (index in visibleRange) 1f else 0f
     }
 
     private fun widthForRange(radii: FloatArray, range: IntRange): Float {
@@ -133,6 +144,7 @@ internal class IndicatorController(
         for (i in 0 until count) {
             val off = Offset(centers[i], size.center.y.toFloat())
             if (offsetTargets.size > i) offsetTargets[i] = off else offsetTargets.add(off)
+            if (alphaTargets.size <= i) alphaTargets.add(alphaFinder(i)) else alphaTargets[i] = alphaFinder(i)
         }
     }
 

--- a/PagerIndicator/src/main/java/com/tek/pagerindicator/PagerIndicator.kt
+++ b/PagerIndicator/src/main/java/com/tek/pagerindicator/PagerIndicator.kt
@@ -104,6 +104,12 @@ internal fun PagerIndicatorKernel(
                 dotAnimation.colorAnim
             )
         )
+        indicatorController.alphas.add(
+            animateFloatAsState(
+                targetValue = indicatorController.alphaTargets[i],
+                dotAnimation.alphaAnim
+            )
+        )
     }
 
 
@@ -118,7 +124,8 @@ internal fun PagerIndicatorKernel(
                 color = indicatorController.colors[i].value,
                 topLeft = topLeft,
                 size = Size(width, height),
-                cornerRadius = CornerRadius(dotStyle.regularDotRadius)
+                cornerRadius = CornerRadius(dotStyle.regularDotRadius),
+                alpha = indicatorController.alphas[i].value
             )
         }
     })


### PR DESCRIPTION
## Summary
- add alpha animation spec to `DotAnimation`
- track opacity values in `IndicatorController`
- animate alpha for dots in `PagerIndicator`

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*
- `./gradlew assembleDebug --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6855bd90b6988324937e3df8731ad26e