### PR TITLE
Fix dot scaling when entering or exiting

### DIFF
--- a/PagerIndicator/src/main/java/com/tek/pagerindicator/PagerIndicator.kt
+++ b/PagerIndicator/src/main/java/com/tek/pagerindicator/PagerIndicator.kt
@@ -115,8 +115,13 @@ internal fun PagerIndicatorKernel(
 
     Canvas(modifier = Modifier.fillMaxSize(), onDraw = {
         for (i in 0 until pageCount) {
-            val width = indicatorController.sizes[i].value * 2
-            val height = dotStyle.regularDotRadius * 2
+            val radius = indicatorController.sizes[i].value
+            val width = radius * 2
+            val height = if (indicatorController.alphas[i].value < 1f) {
+                radius * 2
+            } else {
+                dotStyle.regularDotRadius * 2
+            }
             val topLeft = indicatorController.offSets[i].value -
                 Offset(width / 2f, height / 2f)
 


### PR DESCRIPTION
## Summary
- scale dots from their center when fading in or out

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685953b3f3a88324b7010a69ab630ac2