### PR TITLE
Add arrow navigation to PagerIndicator

### DIFF
--- a/PagerIndicator/build.gradle
+++ b/PagerIndicator/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
+    implementation "androidx.compose.material:material-icons-extended:$compose_version"
     implementation 'com.google.accompanist:accompanist-pager:0.26.1-alpha'
 }
 afterEvaluate {

--- a/PagerIndicator/src/main/java/com/tek/pagerindicator/PagerIndicator.kt
+++ b/PagerIndicator/src/main/java/com/tek/pagerindicator/PagerIndicator.kt
@@ -10,7 +10,11 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.weight
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowForward
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -24,11 +28,6 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.ArrowBack
-import androidx.compose.material.icons.filled.ArrowForward
 import com.google.accompanist.pager.ExperimentalPagerApi
 
 @OptIn(ExperimentalPagerApi::class)
@@ -40,11 +39,9 @@ internal fun PagerIndicatorKernel(
     dotStyle: DotStylePx,
     dotAnimation: DotAnimation = DotAnimation.defaultDotAnimation
 ) {
-    //save page on config changes
     var page by rememberSaveable {
         mutableStateOf(currentIndex)
     }
-    //save displayed range on config changes
     var range by rememberSaveable {
         val start = when {
             pageCount <= dotStyle.visibleDotCount -> 0
@@ -56,7 +53,10 @@ internal fun PagerIndicatorKernel(
             }
         }
         mutableStateOf(
-            RangeChanged(start, kotlin.math.min(start + dotStyle.visibleDotCount - 1, pageCount - 1))
+            RangeChanged(
+                start,
+                kotlin.math.min(start + dotStyle.visibleDotCount - 1, pageCount - 1)
+            )
         )
     }
 
@@ -96,6 +96,7 @@ internal fun PagerIndicatorKernel(
 
 
     indicatorController.clearAll()
+
     for (i in 0 until pageCount) {
         indicatorController.sizes.add(
             animateFloatAsState(
@@ -134,7 +135,7 @@ internal fun PagerIndicatorKernel(
                 dotStyle.regularDotRadius * 2
             }
             val topLeft = indicatorController.offSets[i].value -
-                Offset(width / 2f, height / 2f)
+                    Offset(width / 2f, height / 2f)
 
             drawRoundRect(
                 color = indicatorController.colors[i].value,
@@ -169,7 +170,11 @@ fun PagerIndicator(
             ) {
                 Icon(Icons.Filled.ArrowBack, contentDescription = "Prev")
             }
-            Box(modifier = Modifier.weight(1f).fillMaxHeight()) {
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxHeight()
+            ) {
                 BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
                     val density = LocalDensity.current
                     val h = this.maxHeight
@@ -193,7 +198,10 @@ fun PagerIndicator(
                 onClick = { if (currentIndex < pageCount - 1) onIndexChange(currentIndex + 1) },
                 enabled = currentIndex < pageCount - 1
             ) {
-                Icon(Icons.Filled.ArrowForward, contentDescription = "Next")
+                Icon(
+                    Icons.Filled.ArrowForward,
+                    contentDescription = "Next"
+                )
             }
         }
     } else {

--- a/PagerIndicator/src/main/java/com/tek/pagerindicator/PagerIndicator.kt
+++ b/PagerIndicator/src/main/java/com/tek/pagerindicator/PagerIndicator.kt
@@ -4,20 +4,31 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.animateOffsetAsState
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.weight
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material.icons.filled.ArrowForward
 import com.google.accompanist.pager.ExperimentalPagerApi
 
 @OptIn(ExperimentalPagerApi::class)
@@ -142,25 +153,67 @@ fun PagerIndicator(
     pageCount: Int,
     currentIndex: Int,
     dotStyle: DotStyle = DotStyle.defaultDotStyle,
-    dotAnimation: DotAnimation = DotAnimation.defaultDotAnimation
+    dotAnimation: DotAnimation = DotAnimation.defaultDotAnimation,
+    hasArrow: Boolean = true,
+    onIndexChange: (Int) -> Unit = {}
 ) {
-    BoxWithConstraints(modifier = modifier) {
-        val density = LocalDensity.current
-        val h = this.maxHeight
-        val w = this.maxWidth
-        val stylePx = dotStyle.toPx(density)
-        PagerIndicatorKernel(
-            pageCount = pageCount,
-            currentIndex = currentIndex,
-            intSize = with(density) {
-                IntSize(
-                    w.toPx().toInt(),
-                    h.toPx().toInt()
-                )
-            },
-            dotStyle = stylePx,
-            dotAnimation = dotAnimation
-        )
-
+    if (hasArrow) {
+        Row(
+            modifier = modifier,
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+            IconButton(
+                onClick = { if (currentIndex > 0) onIndexChange(currentIndex - 1) },
+                enabled = currentIndex > 0
+            ) {
+                Icon(Icons.Filled.ArrowBack, contentDescription = "Prev")
+            }
+            Box(modifier = Modifier.weight(1f).fillMaxHeight()) {
+                BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+                    val density = LocalDensity.current
+                    val h = this.maxHeight
+                    val w = this.maxWidth
+                    val stylePx = dotStyle.toPx(density)
+                    PagerIndicatorKernel(
+                        pageCount = pageCount,
+                        currentIndex = currentIndex,
+                        intSize = with(density) {
+                            IntSize(
+                                w.toPx().toInt(),
+                                h.toPx().toInt()
+                            )
+                        },
+                        dotStyle = stylePx,
+                        dotAnimation = dotAnimation
+                    )
+                }
+            }
+            IconButton(
+                onClick = { if (currentIndex < pageCount - 1) onIndexChange(currentIndex + 1) },
+                enabled = currentIndex < pageCount - 1
+            ) {
+                Icon(Icons.Filled.ArrowForward, contentDescription = "Next")
+            }
+        }
+    } else {
+        BoxWithConstraints(modifier = modifier) {
+            val density = LocalDensity.current
+            val h = this.maxHeight
+            val w = this.maxWidth
+            val stylePx = dotStyle.toPx(density)
+            PagerIndicatorKernel(
+                pageCount = pageCount,
+                currentIndex = currentIndex,
+                intSize = with(density) {
+                    IntSize(
+                        w.toPx().toInt(),
+                        h.toPx().toInt()
+                    )
+                },
+                dotStyle = stylePx,
+                dotAnimation = dotAnimation
+            )
+        }
     }
 }

--- a/app/src/main/java/com/tek/pager_indicator/MainActivity.kt
+++ b/app/src/main/java/com/tek/pager_indicator/MainActivity.kt
@@ -4,21 +4,15 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
-import androidx.compose.material.Button
 import androidx.compose.material.Surface
-import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -51,21 +45,7 @@ fun PagerIndicatorContent() {
             .background(Color.LightGray),
         pageCount = pageCount,
         currentIndex = currentIndex,
+        onIndexChange = { currentIndex = it }
     )
-    Row(
-        modifier = Modifier.fillMaxSize(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.Center
-    ) {
-        Column {
-            Button(onClick = { if (currentIndex > 0) currentIndex-- }) {
-                Text("Prev")
-            }
-            Spacer(modifier = Modifier.height(8.dp))
-            Button(onClick = { if (currentIndex < pageCount - 1) currentIndex++ }) {
-                Text("Next")
-            }
-        }
-    }
 }
 


### PR DESCRIPTION
## Summary
- support optional arrow navigation in `PagerIndicator`
- use new arrow API in demo app
- include Compose material icons dependency

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68595d74ef6883248083ccd3a8eb7cae