### PR TITLE
Update PagerIndicator sizing

### DIFF
--- a/PagerIndicator/src/main/java/com/tek/pagerindicator/DotStyle.kt
+++ b/PagerIndicator/src/main/java/com/tek/pagerindicator/DotStyle.kt
@@ -38,6 +38,17 @@ data class DotStyle(
     }
 }
 
+internal fun DotStyle.contentWidth(): Dp {
+    val dotCount = visibleDotCount
+    if (dotCount <= 0) return 0.dp
+    val regularDiameter = regularDotRadius * 2
+    val currentDiameter = currentDotRadius * 2
+    val dotsWidth = currentDiameter + regularDiameter * (dotCount - 1)
+    val spacing = dotMargin * (dotCount - 1)
+    return dotsWidth + spacing
+}
+
+
 internal data class DotStylePx(
     val currentDotRadius: Float,
     val regularDotRadius: Float,
@@ -57,3 +68,14 @@ internal fun DotStyle.toPx(density: Density): DotStylePx = with(density) {
             regularDotColor = regularDotColor
     )
 }
+
+internal fun DotStylePx.contentWidth(): Float {
+    val dotCount = visibleDotCount
+    if (dotCount <= 0) return 0f
+    val regularDiameter = regularDotRadius * 2
+    val currentDiameter = currentDotRadius * 2
+    val dotsWidth = currentDiameter + regularDiameter * (dotCount - 1)
+    val spacing = dotMargin * (dotCount - 1)
+    return dotsWidth + spacing
+}
+

--- a/PagerIndicator/src/main/java/com/tek/pagerindicator/PagerIndicator.kt
+++ b/PagerIndicator/src/main/java/com/tek/pagerindicator/PagerIndicator.kt
@@ -4,12 +4,13 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.animateOffsetAsState
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.icons.Icons
@@ -27,7 +28,9 @@ import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.dp
 import com.google.accompanist.pager.ExperimentalPagerApi
 
 @OptIn(ExperimentalPagerApi::class)
@@ -158,70 +161,50 @@ fun PagerIndicator(
     hasArrow: Boolean = true,
     onIndexChange: (Int) -> Unit = {}
 ) {
-    if (hasArrow) {
-        Row(
-            modifier = modifier,
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween
-        ) {
+    val density = LocalDensity.current
+    val stylePx = dotStyle.toPx(density)
+    val height = 24.dp
+    val widthDots = dotStyle.contentWidth()
+    val size = with(density) { IntSize(widthDots.toPx().toInt(), height.toPx().toInt()) }
+
+    Row(
+        modifier = modifier.height(height),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        if (hasArrow) {
             IconButton(
                 onClick = { if (currentIndex > 0) onIndexChange(currentIndex - 1) },
-                enabled = currentIndex > 0
+                enabled = currentIndex > 0,
+                modifier = Modifier.size(height)
             ) {
                 Icon(Icons.Filled.ArrowBack, contentDescription = "Prev")
             }
-            Box(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxHeight()
-            ) {
-                BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
-                    val density = LocalDensity.current
-                    val h = this.maxHeight
-                    val w = this.maxWidth
-                    val stylePx = dotStyle.toPx(density)
-                    PagerIndicatorKernel(
-                        pageCount = pageCount,
-                        currentIndex = currentIndex,
-                        intSize = with(density) {
-                            IntSize(
-                                w.toPx().toInt(),
-                                h.toPx().toInt()
-                            )
-                        },
-                        dotStyle = stylePx,
-                        dotAnimation = dotAnimation
-                    )
-                }
-            }
-            IconButton(
-                onClick = { if (currentIndex < pageCount - 1) onIndexChange(currentIndex + 1) },
-                enabled = currentIndex < pageCount - 1
-            ) {
-                Icon(
-                    Icons.Filled.ArrowForward,
-                    contentDescription = "Next"
-                )
-            }
+            Spacer(modifier = Modifier.width(4.dp))
         }
-    } else {
-        BoxWithConstraints(modifier = modifier) {
-            val density = LocalDensity.current
-            val h = this.maxHeight
-            val w = this.maxWidth
-            val stylePx = dotStyle.toPx(density)
+
+        Box(
+            modifier = Modifier
+                .width(widthDots)
+                .height(height)
+        ) {
             PagerIndicatorKernel(
                 pageCount = pageCount,
                 currentIndex = currentIndex,
-                intSize = with(density) {
-                    IntSize(
-                        w.toPx().toInt(),
-                        h.toPx().toInt()
-                    )
-                },
+                intSize = size,
                 dotStyle = stylePx,
                 dotAnimation = dotAnimation
             )
         }
+
+        if (hasArrow) {
+            Spacer(modifier = Modifier.width(4.dp))
+            IconButton(
+                onClick = { if (currentIndex < pageCount - 1) onIndexChange(currentIndex + 1) },
+                enabled = currentIndex < pageCount - 1,
+                modifier = Modifier.size(height)
+            ) {
+                Icon(Icons.Filled.ArrowForward, contentDescription = "Next")
+            }
+        }
     }
-}
+

--- a/PagerIndicator/src/main/java/com/tek/pagerindicator/PagerIndicator.kt
+++ b/PagerIndicator/src/main/java/com/tek/pagerindicator/PagerIndicator.kt
@@ -207,4 +207,5 @@ fun PagerIndicator(
             }
         }
     }
+}
 

--- a/app/src/main/java/com/tek/pager_indicator/MainActivity.kt
+++ b/app/src/main/java/com/tek/pager_indicator/MainActivity.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
@@ -13,6 +14,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
@@ -24,10 +26,13 @@ class MainActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
         setContent {
             Surface(modifier = Modifier.fillMaxSize()) {
-                Column(Modifier.fillMaxSize()) {
-                    Column(modifier = Modifier.weight(1f)) {
-                        PagerIndicatorContent()
-                    }
+                Column(
+                    Modifier
+                        .fillMaxSize(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    PagerIndicatorContent()
                 }
             }
         }
@@ -40,9 +45,7 @@ fun PagerIndicatorContent() {
     val pageCount = 11
 
     PagerIndicator(
-        modifier = Modifier
-            .height(50.dp)
-            .background(Color.LightGray),
+        modifier = Modifier,
         pageCount = pageCount,
         currentIndex = currentIndex,
         onIndexChange = { currentIndex = it }


### PR DESCRIPTION
## Summary
- add helper to compute indicator width from DotStyle
- size dots container and arrow buttons with content width and fixed height
- clean unused imports

## Testing
- `./gradlew test` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68596683bdd08324acfeaaca9e62eb45