### PR TITLE
Fix indicator crash on page count change

### DIFF
--- a/PagerIndicator/src/main/java/com/tek/pagerindicator/IndicatorController.kt
+++ b/PagerIndicator/src/main/java/com/tek/pagerindicator/IndicatorController.kt
@@ -188,7 +188,7 @@ internal fun rememberIndicatorController(
     startIndex: Int,
     startRange: IntRange
 ): IndicatorController {
-    return remember {
+    return remember(count, size, dotStyle, startIndex, startRange) {
         IndicatorController(count, size, dotStyle, startIndex, startRange)
     }
 }

--- a/PagerIndicator/src/main/java/com/tek/pagerindicator/PagerIndicator.kt
+++ b/PagerIndicator/src/main/java/com/tek/pagerindicator/PagerIndicator.kt
@@ -44,10 +44,10 @@ internal fun PagerIndicatorKernel(
     dotStyle: DotStylePx,
     dotAnimations: DotAnimationSet = DotAnimationSet()
 ) {
-    var page by rememberSaveable {
-        mutableStateOf(currentIndex)
+    var page by rememberSaveable(pageCount) {
+        mutableStateOf(kotlin.math.min(currentIndex, pageCount - 1))
     }
-    var range by rememberSaveable {
+    var range by rememberSaveable(pageCount) {
         val start = when {
             pageCount <= dotStyle.visibleDotCount -> 0
             else -> {
@@ -65,10 +65,10 @@ internal fun PagerIndicatorKernel(
         )
     }
 
-    var prevPage by remember { mutableStateOf(currentIndex) }
-    var prevRange by remember { mutableStateOf(range) }
-    val enteringIndices = remember { mutableStateListOf<Int>() }
-    val leavingIndices = remember { mutableStateListOf<Int>() }
+    var prevPage by remember(pageCount) { mutableStateOf(kotlin.math.min(currentIndex, pageCount - 1)) }
+    var prevRange by remember(pageCount) { mutableStateOf(range) }
+    val enteringIndices = remember(pageCount) { mutableStateListOf<Int>() }
+    val leavingIndices = remember(pageCount) { mutableStateListOf<Int>() }
     var deselectedIndex by remember { mutableStateOf<Int?>(null) }
 
     fun updateRange(index: Int) {


### PR DESCRIPTION
## Summary
- recreate IndicatorController when params change
- reset range and page when page count updates
- track previous state and index lists per page count

## Testing
- `./gradlew :PagerIndicator:assembleDebug -x lint` *(fails: Unable to download Gradle due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685d4588aa80832496af4a37acab5472